### PR TITLE
Refactor master tab contest into separate function

### DIFF
--- a/addon/services/master-tab-factory.js
+++ b/addon/services/master-tab-factory.js
@@ -73,24 +73,7 @@ export default Ember.Service.extend(Ember.Evented, {
         debug('Unregistered as master tab. ');
       }
     });
-    return new Ember.RSVP.Promise(resolve => {
-      if (!this.registerAsMasterTab()) {
-        debug('Trying to invalidate master tab.');
-        this.resolve = resolve;
-        this.contestTimeout = setTimeout(() => {
-          const shouldInvalidateMasterTab = eval(localStorage[shouldInvalidateMasterTabKey]);
-          if (shouldInvalidateMasterTab) {
-            localStorage[shouldInvalidateMasterTabKey] = false;
-            delete localStorage[tabIdKey];
-            this.registerAsMasterTab();
-          }
-          resolve();
-        }, 500);
-        localStorage[shouldInvalidateMasterTabKey] = true;
-      } else {
-        resolve();
-      }
-    });
+    return this.contestMasterTab();
   },
   isMasterTab: false,
   /** Tries to register as the master tab if there is no current master tab registered. */
@@ -111,6 +94,30 @@ export default Ember.Service.extend(Ember.Evented, {
       this.trigger('isMasterTab', success);
     });
     return success;
+  },
+
+  /**
+   * Returns a promise which attempts to contest the master tab.
+   */
+  contestMasterTab() {
+    return new Ember.RSVP.Promise(resolve => {
+      if (!this.registerAsMasterTab()) {
+        debug('Trying to invalidate master tab.');
+        this.resolve = resolve;
+        this.contestTimeout = setTimeout(() => {
+          const shouldInvalidateMasterTab = eval(localStorage[shouldInvalidateMasterTabKey]);
+          if (shouldInvalidateMasterTab) {
+            localStorage[shouldInvalidateMasterTabKey] = false;
+            delete localStorage[tabIdKey];
+            this.registerAsMasterTab();
+          }
+          resolve();
+        }, 500);
+        localStorage[shouldInvalidateMasterTabKey] = true;
+      } else {
+        resolve();
+      }
+    });
   },
   /**
    * Runs the provided function if this is the master tab. If this is not the current tab, run

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -20,7 +20,10 @@ export default Ember.Controller.extend({
     Ember.run.later(() => {
       this.get('masterTab')
         .run(() => this.incrementProperty('counterIsMasterTab'))
-        .else(() => this.incrementProperty('counterIsNotMasterTab'));
+        .else(() => {
+          this.incrementProperty('counterIsNotMasterTab');
+          this.get('masterTab').contestMasterTab();
+        });
       this.incrementCounter();
     }, 1000);
   },


### PR DESCRIPTION
With the master tab contest as a separate function, consuming apps can implement their own logic to cope with tab crashes however they see fit (periodic contest, contest on `else()`, etc).

Initiating a master tab contest from a consuming app is easy: simply call `this.get('masterTab').contestMasterTab();`.